### PR TITLE
chore: migrate to pnpm 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
       - name: Install packages
         run: pnpm install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
       - name: Install packages
         run: pnpm install

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "@types/react-dom": "19.1.6",
     "typescript": "5.8.3"
   },
-  "packageManager": "pnpm@10.13.1"
+  "packageManager": "pnpm@11.3.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+minimumReleaseAge: 1440

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,2 @@
 allowBuilds:
   esbuild: true
-minimumReleaseAge: 1440


### PR DESCRIPTION
Migrates the project to pnpm 11.

- Bumps `packageManager` to `pnpm@11.3.0` in `package.json`.
- Approves the `esbuild` dependency build script via `allowBuilds` in `pnpm-workspace.yaml`, so pnpm 11 doesn't fail CI on ignored build scripts.
- Bumps CI Node to 22 in both `build.yml` and `lint.yml` workflows to satisfy pnpm 11's Node >= 22.13 requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
