### PR TITLE
chore(ci): replace buildjet runners with depot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-4
     container:
       image: node:22
       credentials:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   lint:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-4
     container:
       image: node:22
       credentials:

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   pin-dependencies-check:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-4
     container:
       image: node:22
       credentials:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, edited, synchronize]
 jobs:
   pr-title-check:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-4
     container:
       image: node:22
       credentials:


### PR DESCRIPTION
BuildJet is no longer paid for, which caused CI to hang forever waiting for runners that never start.

This switches all GitHub Actions workflows from the BuildJet runner (`buildjet-4vcpu-ubuntu-2204`) to Depot (`depot-ubuntu-22.04-4`), matching the runner setup used across other Resend repos.

Files changed:
- `.github/workflows/build.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/pin-dependencies-check.yml`
- `.github/workflows/pr-title-check.yml`

Only the `runs-on` value changed in each workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)